### PR TITLE
Add initial nsys.netperftesting Ansible collection skeleton

### DIFF
--- a/ansible_collections/nsys/netperftesting/README.md
+++ b/ansible_collections/nsys/netperftesting/README.md
@@ -1,0 +1,13 @@
+# nsys.netperftesting
+
+An Ansible collection for running network performance tests on network equipment and servers.
+
+Currently supports Mikrotik switches and Debian servers.
+
+## Requirements
+
+See `requirements.txt` for the required Python packages.
+
+## Usage
+
+This is an initial skeleton; playbooks and roles will be added in future releases.

--- a/ansible_collections/nsys/netperftesting/docs/README.md
+++ b/ansible_collections/nsys/netperftesting/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+Collection documentation will be added here.

--- a/ansible_collections/nsys/netperftesting/galaxy.yml
+++ b/ansible_collections/nsys/netperftesting/galaxy.yml
@@ -1,0 +1,15 @@
+namespace: nsys
+name: netperftesting
+version: 0.1.0
+readme: README.md
+authors:
+  - N-one Systems
+description: >-
+  Ansible collection for network performance testing on Mikrotik switches and Debian servers.
+license: MIT
+tags:
+  - networking
+  - performance
+  - mikrotik
+  - debian
+  - testing

--- a/ansible_collections/nsys/netperftesting/playbooks/README.md
+++ b/ansible_collections/nsys/netperftesting/playbooks/README.md
@@ -1,0 +1,3 @@
+# Playbooks
+
+Sample playbooks for network performance testing will be placed here.

--- a/ansible_collections/nsys/netperftesting/plugins/README.md
+++ b/ansible_collections/nsys/netperftesting/plugins/README.md
@@ -1,0 +1,3 @@
+# Plugins
+
+Custom Ansible plugins for the collection will go here.

--- a/ansible_collections/nsys/netperftesting/requirements.txt
+++ b/ansible_collections/nsys/netperftesting/requirements.txt
@@ -1,0 +1,1 @@
+ansible-core==2.19.0

--- a/ansible_collections/nsys/netperftesting/roles/README.md
+++ b/ansible_collections/nsys/netperftesting/roles/README.md
@@ -1,0 +1,3 @@
+# Roles
+
+Ansible roles for network performance testing will be added here.


### PR DESCRIPTION
## Summary
- scaffold nsys.netperftesting collection structure with documentation, playbooks, plugins, and roles placeholders
- define collection metadata at version 0.1.0 with description for Mikrotik and Debian performance tests
- include requirements file pinning ansible-core

## Testing
- `pip install -r ansible_collections/nsys/netperftesting/requirements.txt`
- `ansible-galaxy collection build ansible_collections/nsys/netperftesting --output-path /tmp`


------
https://chatgpt.com/codex/tasks/task_b_68a42b37f150832483888436dbd0aa10