### PR TITLE
Add iperf3_server role

### DIFF
--- a/netperftesting/roles/README.md
+++ b/netperftesting/roles/README.md
@@ -1,3 +1,6 @@
 # Roles
 
-Ansible roles for network performance testing will be added here.
+Ansible roles for network performance testing:
+
+- **iperf3_server**: Installs iperf3 and provides a systemd template
+  to run multiple iperf3 server instances on different ports.

--- a/netperftesting/roles/iperf3_server/README.md
+++ b/netperftesting/roles/iperf3_server/README.md
@@ -1,0 +1,4 @@
+# iperf3_server role
+
+Installs iperf3 and provides a systemd template unit (`iperf3@.service`)
+to allow multiple iperf3 server instances to run on different ports.

--- a/netperftesting/roles/iperf3_server/defaults/main.yml
+++ b/netperftesting/roles/iperf3_server/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+iperf3_server_package: iperf3

--- a/netperftesting/roles/iperf3_server/handlers/main.yml
+++ b/netperftesting/roles/iperf3_server/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+  become: true

--- a/netperftesting/roles/iperf3_server/tasks/main.yml
+++ b/netperftesting/roles/iperf3_server/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Install iperf3
+  ansible.builtin.package:
+    name: "{{ iperf3_server_package }}"
+    state: present
+  become: true
+
+- name: Deploy iperf3 systemd template
+  ansible.builtin.template:
+    src: iperf3@.service.j2
+    dest: /etc/systemd/system/iperf3@.service
+    owner: root
+    group: root
+    mode: '0644'
+  become: true
+  notify: Reload systemd

--- a/netperftesting/roles/iperf3_server/templates/iperf3@.service.j2
+++ b/netperftesting/roles/iperf3_server/templates/iperf3@.service.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=iperf3 server on port %i
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/iperf3 -s -p %i
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add iperf3_server role to install iperf3
- provide systemd template for running multiple iperf3 servers

## Testing
- `ansible-lint netperftesting/roles/iperf3_server`
- `ANSIBLE_ROLES_PATH=netperftesting/roles ansible-playbook -i localhost, -c local /tmp/test_playbook.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_b_68a43a1ba89083248158e133a8dd9820