### PR TITLE
Add iperf3 client role with systemd template

### DIFF
--- a/netperftesting/roles/README.md
+++ b/netperftesting/roles/README.md
@@ -4,3 +4,5 @@ Ansible roles for network performance testing:
 
 - **iperf3_server**: Installs iperf3 and provides a systemd template
   to run multiple iperf3 server instances on different ports.
+- **iperf3_client**: Installs iperf3 and provides a systemd template to
+  run multiple iperf3 clients with per-instance configuration files.

--- a/netperftesting/roles/iperf3_client/README.md
+++ b/netperftesting/roles/iperf3_client/README.md
@@ -1,0 +1,32 @@
+# iperf3_client role
+
+Installs iperf3 and provides a systemd template unit (`iperf3-client@.service`)
+to run multiple iperf3 client instances with per-instance configuration files.
+Each configuration file defines `TARGET_IP`, `TARGET_PORT`, `PROTOCOL`, and
+optional `EXTRA_ARGS` variables used by the service to connect to different
+servers, ports, and protocols.
+
+## Variables
+
+- `iperf3_client_instances`: List of client service definitions. Each item
+  should include:
+  - `name`: Instance name (used for configuration file and systemd unit)
+  - `target`: Target host IP or name
+  - `port`: Target port or `default+<offset>` to offset from the default
+  - `protocol`: `tcp` (default) or `udp`
+  - `bandwidth` (optional): Bandwidth for UDP tests
+  - `extra_args` (optional): Additional iperf3 arguments
+
+Example:
+
+```yaml
+iperf3_client_instances:
+  - name: test_network1
+    target: 192.168.10.11
+    port: default+1
+    protocol: udp
+    bandwidth: 0
+  - name: test_network2
+    target: 192.168.10.12
+    port: default+2
+```

--- a/netperftesting/roles/iperf3_client/defaults/main.yml
+++ b/netperftesting/roles/iperf3_client/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+iperf3_client_package: iperf3
+iperf3_client_conf_dir: /etc/iperf3-client
+iperf3_client_base_port: 5201
+iperf3_client_instances: []

--- a/netperftesting/roles/iperf3_client/handlers/main.yml
+++ b/netperftesting/roles/iperf3_client/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+  become: true

--- a/netperftesting/roles/iperf3_client/tasks/main.yml
+++ b/netperftesting/roles/iperf3_client/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+- name: Install iperf3
+  ansible.builtin.package:
+    name: "{{ iperf3_client_package }}"
+    state: present
+  become: true
+
+- name: Ensure iperf3 client config directory exists
+  ansible.builtin.file:
+    path: "{{ iperf3_client_conf_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  become: true
+
+- name: Deploy iperf3 client systemd template
+  ansible.builtin.template:
+    src: iperf3-client@.service.j2
+    dest: /etc/systemd/system/iperf3-client@.service
+    owner: root
+    group: root
+    mode: '0644'
+  become: true
+  notify: Reload systemd
+
+- name: Render iperf3 client configs
+  ansible.builtin.template:
+    src: iperf3-client.conf.j2
+    dest: "{{ iperf3_client_conf_dir }}/{{ item.name }}.conf"
+    owner: root
+    group: root
+    mode: '0644'
+  loop: "{{ iperf3_client_instances }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: iperf3_client_instances | length > 0
+  become: true
+
+- name: Enable iperf3 client services
+  ansible.builtin.systemd:
+    name: "iperf3-client@{{ item.name }}"
+    enabled: true
+    state: started
+  loop: "{{ iperf3_client_instances }}"
+  loop_control:
+    label: "iperf3-client@{{ item.name }}"
+  when: iperf3_client_instances | length > 0
+  become: true

--- a/netperftesting/roles/iperf3_client/templates/iperf3-client.conf.j2
+++ b/netperftesting/roles/iperf3_client/templates/iperf3-client.conf.j2
@@ -1,0 +1,19 @@
+{% set base_port = iperf3_client_base_port | int %}
+TARGET_IP={{ item.target }}
+{% if item.port is string and 'default+' in item.port %}
+TARGET_PORT={{ base_port + (item.port.split('+')[1] | int) }}
+{% else %}
+TARGET_PORT={{ item.port | default(base_port) }}
+{% endif %}
+{% if item.protocol | default('tcp') == 'udp' %}
+PROTOCOL=--udp
+{% else %}
+PROTOCOL=
+{% endif %}
+{% if item.extra_args is defined %}
+EXTRA_ARGS={{ item.extra_args }}
+{% elif item.bandwidth is defined %}
+EXTRA_ARGS=-b {{ item.bandwidth }}
+{% else %}
+EXTRA_ARGS=
+{% endif %}

--- a/netperftesting/roles/iperf3_client/templates/iperf3-client@.service.j2
+++ b/netperftesting/roles/iperf3_client/templates/iperf3-client@.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=iperf3 client instance %i
+After=network.target
+
+[Service]
+Type=simple
+EnvironmentFile=-{{ iperf3_client_conf_dir }}/%i.conf
+ExecStart=/usr/bin/iperf3 -c $TARGET_IP -p $TARGET_PORT $PROTOCOL $EXTRA_ARGS
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add iperf3_client role to install iperf3 and provide configurable systemd template
- document iperf3_client role in roles README
- refine client systemd template to expose TARGET_IP, TARGET_PORT, PROTOCOL and EXTRA_ARGS variables
- add config template and tasks to create iperf3 client services from iperf3_client_instances

## Testing
- `env ANSIBLE_ROLES_PATH=netperftesting/roles ansible-playbook -i localhost, -c local --syntax-check /tmp/test_playbook.yml`

------
https://chatgpt.com/codex/tasks/task_b_68a43d7c0f0083248fd5be0d08e94624