### PR TITLE
Improve iperf3 service management and logging

### DIFF
--- a/netperftesting/roles/iperf3_client/README.md
+++ b/netperftesting/roles/iperf3_client/README.md
@@ -17,6 +17,11 @@ servers, ports, and protocols.
   - `bandwidth` (optional): Bandwidth for UDP tests
   - `extra_args` (optional): Additional iperf3 arguments
 
+- `iperf3_client_auto_start`: Whether client services should be started
+  automatically after configuration. Defaults to `true`.
+- `iperf3_client_auto_enable`: Whether client services should be enabled to
+  start at boot. Defaults to `true`.
+
 Example:
 
 ```yaml

--- a/netperftesting/roles/iperf3_client/defaults/main.yml
+++ b/netperftesting/roles/iperf3_client/defaults/main.yml
@@ -3,3 +3,5 @@ iperf3_client_package: iperf3
 iperf3_client_conf_dir: /etc/iperf3-client
 iperf3_client_base_port: 5201
 iperf3_client_instances: []
+iperf3_client_auto_start: true
+iperf3_client_auto_enable: true

--- a/netperftesting/roles/iperf3_client/tasks/main.yml
+++ b/netperftesting/roles/iperf3_client/tasks/main.yml
@@ -37,11 +37,26 @@
   when: iperf3_client_instances | length > 0
   become: true
 
-- name: Enable iperf3 client services
+- name: Find existing client configs
+  ansible.builtin.find:
+    paths: "{{ iperf3_client_conf_dir }}"
+    patterns: "*.conf"
+  register: iperf3_client_existing_configs
+  become: true
+
+- name: Remove obsolete client configs
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ iperf3_client_existing_configs.files }}"
+  when: item.path | basename | regex_replace('\\.conf$', '') not in (iperf3_client_instances | map(attribute='name'))
+  become: true
+
+- name: Enable and start iperf3 client services
   ansible.builtin.systemd:
     name: "iperf3-client@{{ item.name }}"
-    enabled: true
-    state: started
+    enabled: "{{ iperf3_client_auto_enable }}"
+    state: "{{ 'started' if iperf3_client_auto_start else 'stopped' }}"
   loop: "{{ iperf3_client_instances }}"
   loop_control:
     label: "iperf3-client@{{ item.name }}"

--- a/netperftesting/roles/iperf3_client/templates/iperf3-client@.service.j2
+++ b/netperftesting/roles/iperf3_client/templates/iperf3-client@.service.j2
@@ -1,12 +1,18 @@
 [Unit]
 Description=iperf3 client instance %i
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple
+User=nobody
+Group=nogroup
 EnvironmentFile=-{{ iperf3_client_conf_dir }}/%i.conf
 ExecStart=/usr/bin/iperf3 -c $TARGET_IP -p $TARGET_PORT $PROTOCOL $EXTRA_ARGS
 Restart=on-failure
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=iperf3-client-%i
 
 [Install]
 WantedBy=multi-user.target

--- a/netperftesting/roles/iperf3_server/README.md
+++ b/netperftesting/roles/iperf3_server/README.md
@@ -2,3 +2,8 @@
 
 Installs iperf3 and provides a systemd template unit (`iperf3@.service`)
 to allow multiple iperf3 server instances to run on different ports.
+
+## Variables
+
+- `iperf3_server_instances`: List of ports to run server instances on.
+  Defaults to `[]`.

--- a/netperftesting/roles/iperf3_server/defaults/main.yml
+++ b/netperftesting/roles/iperf3_server/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 iperf3_server_package: iperf3
+iperf3_server_instances: []

--- a/netperftesting/roles/iperf3_server/tasks/main.yml
+++ b/netperftesting/roles/iperf3_server/tasks/main.yml
@@ -14,3 +14,12 @@
     mode: '0644'
   become: true
   notify: Reload systemd
+
+- name: Enable iperf3 server instances
+  ansible.builtin.systemd:
+    name: "iperf3@{{ item }}"
+    enabled: true
+    state: started
+  loop: "{{ iperf3_server_instances }}"
+  when: iperf3_server_instances | length > 0
+  become: true

--- a/netperftesting/roles/iperf3_server/templates/iperf3@.service.j2
+++ b/netperftesting/roles/iperf3_server/templates/iperf3@.service.j2
@@ -1,11 +1,17 @@
 [Unit]
 Description=iperf3 server on port %i
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple
+User=nobody
+Group=nogroup
 ExecStart=/usr/bin/iperf3 -s -p %i
 Restart=on-failure
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=iperf3-server-%i
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add automatic enable/start controls and cleanup tasks for iperf3 client services
- support managing iperf3 server instances and enhance systemd units with dependencies, isolation, and logging

## Testing
- `ansible-lint netperftesting/roles/iperf3_client netperftesting/roles/iperf3_server`

------
https://chatgpt.com/codex/tasks/task_b_68a44444e8c8832481ad5a382fc0784f