### PR TITLE
Add Molecule scenario for netperftesting

### DIFF
--- a/netperftesting/molecule/default/converge.yml
+++ b/netperftesting/molecule/default/converge.yml
@@ -1,0 +1,10 @@
+---
+- name: Configure iperf3 servers
+  hosts: servers
+  roles:
+    - role: iperf3_server
+
+- name: Configure iperf3 clients
+  hosts: clients
+  roles:
+    - role: iperf3_client

--- a/netperftesting/molecule/default/molecule.yml
+++ b/netperftesting/molecule/default/molecule.yml
@@ -1,0 +1,58 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+platforms:
+  - name: server1
+    image: geerlingguy/docker-debian12-ansible:latest
+    command: /sbin/init
+    privileged: true
+    pre_build_image: true
+    groups:
+      - servers
+  - name: server2
+    image: geerlingguy/docker-debian12-ansible:latest
+    command: /sbin/init
+    privileged: true
+    pre_build_image: true
+    groups:
+      - servers
+  - name: client1
+    image: geerlingguy/docker-debian12-ansible:latest
+    command: /sbin/init
+    privileged: true
+    pre_build_image: true
+    groups:
+      - clients
+  - name: client2
+    image: geerlingguy/docker-debian12-ansible:latest
+    command: /sbin/init
+    privileged: true
+    pre_build_image: true
+    groups:
+      - clients
+
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+  inventory:
+    group_vars:
+      servers:
+        iperf3_server_instances:
+          - 5201
+    host_vars:
+      client1:
+        iperf3_client_instances:
+          - name: to-server1
+            target: server1
+      client2:
+        iperf3_client_instances:
+          - name: to-server2
+            target: server2
+
+verifier:
+  name: ansible

--- a/netperftesting/molecule/default/verify.yml
+++ b/netperftesting/molecule/default/verify.yml
@@ -1,0 +1,19 @@
+---
+- name: Verify iperf3 services
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Check iperf3 server service
+      ansible.builtin.command: systemctl is-active iperf3@5201
+      changed_when: false
+      when: "'servers' in group_names"
+
+    - name: Check iperf3 client to server1 service
+      ansible.builtin.command: systemctl is-active iperf3-client@to-server1
+      changed_when: false
+      when: inventory_hostname == 'client1'
+
+    - name: Check iperf3 client to server2 service
+      ansible.builtin.command: systemctl is-active iperf3-client@to-server2
+      changed_when: false
+      when: inventory_hostname == 'client2'


### PR DESCRIPTION
## Summary
- add Molecule scenario using Docker with two servers and two clients for iperf3 roles

## Testing
- `molecule test` *(fails: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_b_68a447fad6488324a818b32de17f45a0