### PR TITLE
Specify iperf3 client ports in Molecule scenario

### DIFF
--- a/netperftesting/molecule/default/molecule.yml
+++ b/netperftesting/molecule/default/molecule.yml
@@ -75,10 +75,12 @@ provisioner:
         iperf3_client_instances:
           - name: to-server1
             target: server1
+            port: 5201
       client2:
         iperf3_client_instances:
           - name: to-server2
             target: server2
+            port: 5201
 
 verifier:
   name: ansible


### PR DESCRIPTION
## Summary
- set port for iperf3_client_instances in Molecule host vars to ensure iperf3 client configs render correctly

## Testing
- `molecule test` *(fails: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_b_68a461edadb48324bd27cc6ae27bd794