### PR TITLE
Keep iperf3 client service running during Molecule verify

### DIFF
--- a/netperftesting/roles/iperf3_client/templates/iperf3-client@.service.j2
+++ b/netperftesting/roles/iperf3_client/templates/iperf3-client@.service.j2
@@ -2,14 +2,16 @@
 Description=iperf3 client instance %i
 After=network-online.target
 Wants=network-online.target
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 User=nobody
 Group=nogroup
 EnvironmentFile=-{{ iperf3_client_conf_dir }}/%i.conf
-ExecStart=/usr/bin/iperf3 -c $TARGET_IP -p $TARGET_PORT $PROTOCOL $EXTRA_ARGS
+ExecStart=/usr/bin/iperf3 -c $TARGET_IP -p $TARGET_PORT $PROTOCOL -t 0 $EXTRA_ARGS
 Restart=on-failure
+RestartSec=5
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=iperf3-client-%i


### PR DESCRIPTION
## Summary
- run iperf3 client services indefinitely
- slow restarts to avoid systemd start limits

## Testing
- `molecule test` *(fails: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_b_68a46d12e58c83249247626778097ab8