### PR TITLE
Add full mesh iperf3 sample playbook

### DIFF
--- a/netperftesting/playbooks/README.md
+++ b/netperftesting/playbooks/README.md
@@ -1,3 +1,9 @@
 # Playbooks
 
 Sample playbooks for network performance testing will be placed here.
+
+## Available Samples
+
+- `netperf_fullmesh.yml` - uses the `sample_inventory.yaml` inventory and
+  deploys a full mesh of iperf3 server and client instances so that every host
+  in the `servers` group tests connectivity with all other hosts.

--- a/netperftesting/playbooks/netperf_fullmesh.yml
+++ b/netperftesting/playbooks/netperf_fullmesh.yml
@@ -1,0 +1,33 @@
+---
+- name: Full mesh iperf3 test
+  hosts: servers
+  gather_facts: false
+  collections:
+    - nsys.netperftesting
+  vars:
+    base_port: 5200
+  tasks:
+    - name: Initialize instance lists
+      ansible.builtin.set_fact:
+        iperf3_server_instances: []
+        iperf3_client_instances: []
+
+    - name: Build iperf3 server and client instance lists
+      ansible.builtin.set_fact:
+        iperf3_server_instances: "{{ iperf3_server_instances + [ base_port + hostvars[item].id ] }}"
+        iperf3_client_instances: "{{ iperf3_client_instances + [ { 'name': item, 'target': hostvars[item].test_ip.split('/') | first, 'port': base_port + hostvars[inventory_hostname].id } ] }}"
+      loop: "{{ groups['servers'] }}"
+      when: item != inventory_hostname
+
+    - name: Configure iperf3 servers
+      ansible.builtin.include_role:
+        name: iperf3_server
+      vars:
+        iperf3_server_instances: "{{ iperf3_server_instances }}"
+
+    - name: Configure iperf3 clients
+      ansible.builtin.include_role:
+        name: iperf3_client
+      vars:
+        iperf3_client_instances: "{{ iperf3_client_instances }}"
+        iperf3_client_base_port: "{{ base_port }}"


### PR DESCRIPTION
## Summary
- document available sample playbooks
- add a netperf playbook that launches a full mesh of iperf3 servers and clients between hosts

## Testing
- `ansible-playbook -i sample_inventory.yaml netperftesting/playbooks/netperf_fullmesh.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_b_68a477b0a1288324af8225848e5d4479