### PR TITLE
Run iperf3 services under dedicated user

### DIFF
--- a/netperftesting/roles/iperf3_client/README.md
+++ b/netperftesting/roles/iperf3_client/README.md
@@ -5,7 +5,9 @@ to run multiple iperf3 client instances with per-instance configuration files.
 Each run logs to `journald` and stores its JSON results in a per-connection file
 for later analysis. Each configuration file defines `TARGET_IP`, `TARGET_PORT`,
 `PROTOCOL`, and optional `EXTRA_ARGS` variables used by the service to connect
-to different servers, ports, and protocols.
+to different servers, ports, and protocols. All services execute as a minimal
+`iperf3` system user; the role ensures this user exists and that the log
+directory is owned by it.
 
 ## Variables
 

--- a/netperftesting/roles/iperf3_client/tasks/main.yml
+++ b/netperftesting/roles/iperf3_client/tasks/main.yml
@@ -5,6 +5,15 @@
     state: present
   become: true
 
+- name: Ensure iperf3 system user exists
+  ansible.builtin.user:
+    name: iperf3
+    system: true
+    shell: /usr/sbin/nologin
+    create_home: false
+    home: /nonexistent
+  become: true
+
 - name: Ensure iperf3 client config directory exists
   ansible.builtin.file:
     path: "{{ iperf3_client_conf_dir }}"
@@ -18,8 +27,8 @@
   ansible.builtin.file:
     path: "{{ iperf3_client_log_dir }}"
     state: directory
-    owner: nobody
-    group: nogroup
+    owner: iperf3
+    group: iperf3
     mode: '0755'
   become: true
 

--- a/netperftesting/roles/iperf3_client/templates/iperf3-client@.service.j2
+++ b/netperftesting/roles/iperf3_client/templates/iperf3-client@.service.j2
@@ -5,8 +5,8 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=nobody
-Group=nogroup
+User=iperf3
+Group=iperf3
 EnvironmentFile=-{{ iperf3_client_conf_dir }}/%i.conf
 ExecStart=/bin/sh -c "/usr/bin/iperf3 -c $TARGET_IP -p $TARGET_PORT $PROTOCOL $EXTRA_ARGS -J | tee {{ iperf3_client_log_dir }}/{{ inventory_hostname }}-to-%i.json"
 Restart=on-failure

--- a/netperftesting/roles/iperf3_server/README.md
+++ b/netperftesting/roles/iperf3_server/README.md
@@ -1,7 +1,9 @@
 # iperf3_server role
 
 Installs iperf3 and provides a systemd template unit (`iperf3@.service`)
-to allow multiple iperf3 server instances to run on different ports.
+to allow multiple iperf3 server instances to run on different ports. Services
+run under a dedicated `iperf3` system user with no shell for minimal
+privileges.
 
 ## Variables
 

--- a/netperftesting/roles/iperf3_server/tasks/main.yml
+++ b/netperftesting/roles/iperf3_server/tasks/main.yml
@@ -5,6 +5,15 @@
     state: present
   become: true
 
+- name: Ensure iperf3 system user exists
+  ansible.builtin.user:
+    name: iperf3
+    system: true
+    shell: /usr/sbin/nologin
+    create_home: false
+    home: /nonexistent
+  become: true
+
 - name: Deploy iperf3 systemd template
   ansible.builtin.template:
     src: iperf3@.service.j2

--- a/netperftesting/roles/iperf3_server/templates/iperf3@.service.j2
+++ b/netperftesting/roles/iperf3_server/templates/iperf3@.service.j2
@@ -5,8 +5,8 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=nobody
-Group=nogroup
+User=iperf3
+Group=iperf3
 ExecStart=/usr/bin/iperf3 -s -p %i
 Restart=on-failure
 StandardOutput=journal


### PR DESCRIPTION
## Summary
- Run iperf3 server and client systemd units as a dedicated `iperf3` user instead of `nobody`.
- Create a minimal `iperf3` system account and ensure client log directory ownership.
- Document use of the new restricted user in role READMEs.

## Testing
- `pip install -r netperftesting/dev-requirements.txt`
- `molecule test` *(fails: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_b_68a4ad547c40832484b74b69fe40cb64