### PR TITLE
Add UDP stress testing playbook

### DIFF
--- a/netperftesting/playbooks/README.md
+++ b/netperftesting/playbooks/README.md
@@ -9,6 +9,8 @@ Sample playbooks for network performance testing will be placed here.
   in the `servers` group tests connectivity with all other hosts.
 - `netperf_single_client.yml` - designates one host as the client and runs
   iperf3 tests against all other hosts.
+- `netperf_stress.yml` - launches multiple concurrent UDP streams between all
+  hosts for high-stress testing.
 
 ### `netperf_single_client.yml`
 
@@ -46,4 +48,26 @@ Run a UDP test with an optional bandwidth limit:
 ```bash
 ansible-playbook -i inventory.yaml netperftesting/playbooks/netperf_single_client.yml \
   -e "protocol=udp bandwidth=100M"
+```
+
+### `netperf_stress.yml`
+
+This playbook starts `connections_per_pair` iperf3 server instances on each
+host for every other host and launches the same number of UDP clients toward
+each peer. Clients run with unlimited bandwidth (`-b 0`) for
+`test_duration` seconds (default `600`) to maximize network load.
+
+#### Usage
+
+Run with defaults:
+
+```bash
+ansible-playbook -i inventory.yaml netperftesting/playbooks/netperf_stress.yml
+```
+
+Specify five connections per pair for 300-second runs:
+
+```bash
+ansible-playbook -i inventory.yaml netperftesting/playbooks/netperf_stress.yml \
+  -e "connections_per_pair=5 test_duration=300"
 ```

--- a/netperftesting/playbooks/netperf_stress.yml
+++ b/netperftesting/playbooks/netperf_stress.yml
@@ -1,0 +1,43 @@
+---
+- name: Stress test iperf3 UDP connections
+  hosts: test_hosts
+  gather_facts: false
+  vars:
+    base_port: 5200
+    connections_per_pair: 1
+    test_duration: 600
+  tasks:
+    - name: Initialize instance lists
+      ansible.builtin.set_fact:
+        iperf3_server_instances: []
+        iperf3_client_instances: []
+
+    - name: Build iperf3 server instance list
+      ansible.builtin.set_fact:
+        iperf3_server_instances: "{{ iperf3_server_instances + [base_port + hostvars[pair[0]].id * connections_per_pair + pair[1]] }}"
+      loop: "{{ (ansible_play_hosts | difference([inventory_hostname])) | product(range(connections_per_pair | int)) | list }}"
+      loop_control:
+        loop_var: pair
+
+    - name: Build iperf3 client instance list
+      ansible.builtin.set_fact:
+        iperf3_client_instances: "{{ iperf3_client_instances + [{
+            'name': pair[0] ~ '_' ~ pair[1],
+            'target': hostvars[pair[0]].test_ip.split('/') | first,
+            'port': base_port + hostvars[inventory_hostname].id * connections_per_pair + pair[1],
+            'protocol': 'udp',
+            'extra_args': '-b 0 -t ' ~ (test_duration | string)
+          }] }}"
+      loop: "{{ (ansible_play_hosts | difference([inventory_hostname])) | product(range(connections_per_pair | int)) | list }}"
+      loop_control:
+        loop_var: pair
+
+    - name: Configure iperf3 servers
+      ansible.builtin.include_role:
+        name: nsys.netperftesting.iperf3_server
+
+    - name: Configure iperf3 clients
+      ansible.builtin.include_role:
+        name: nsys.netperftesting.iperf3_client
+      vars:
+        iperf3_client_base_port: "{{ base_port }}"


### PR DESCRIPTION
## Summary
- add `netperf_stress.yml` to run multiple concurrent UDP iperf3 streams between all hosts
- document usage and options for the new playbook

## Testing
- `ansible-lint netperftesting/playbooks/netperf_stress.yml`
- `ansible-playbook -i sample_inventory.yaml netperftesting/playbooks/netperf_stress.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_b_68a4b26265348324995bf49e1c9abc11