### PR TITLE
Add single server iperf3 test playbook

### DIFF
--- a/netperftesting/playbooks/README.md
+++ b/netperftesting/playbooks/README.md
@@ -9,6 +9,8 @@ Sample playbooks for network performance testing will be placed here.
   in the `servers` group tests connectivity with all other hosts.
 - `netperf_single_client.yml` - designates one host as the client and runs
   iperf3 tests against all other hosts.
+- `netperf_single_server.yml` - designates one host as the server and runs
+  iperf3 tests from all other hosts.
 - `netperf_stress.yml` - launches multiple concurrent UDP streams between all
   hosts for high-stress testing.
 
@@ -47,6 +49,44 @@ Run a UDP test with an optional bandwidth limit:
 
 ```bash
 ansible-playbook -i inventory.yaml netperftesting/playbooks/netperf_single_client.yml \
+  -e "protocol=udp bandwidth=100M"
+```
+
+### `netperf_single_server.yml`
+
+This playbook starts an `iperf3_server` instance on the host specified by the
+`server_host` variable. All other hosts connect to the designated server using
+the `iperf3_client` role.
+
+#### Inventory example
+
+```yaml
+all:
+  vars:
+    server_host: deb-srv-01
+  children:
+    test_hosts:
+      hosts:
+        deb-srv-01:
+          test_ip: 192.168.254.11/24
+        deb-srv-02:
+          test_ip: 192.168.254.12/24
+        deb-srv-03:
+          test_ip: 192.168.254.13/24
+```
+
+#### Usage
+
+Run a TCP test (default protocol):
+
+```bash
+ansible-playbook -i inventory.yaml netperftesting/playbooks/netperf_single_server.yml
+```
+
+Run a UDP test with an optional bandwidth limit:
+
+```bash
+ansible-playbook -i inventory.yaml netperftesting/playbooks/netperf_single_server.yml \
   -e "protocol=udp bandwidth=100M"
 ```
 

--- a/netperftesting/playbooks/netperf_single_server.yml
+++ b/netperftesting/playbooks/netperf_single_server.yml
@@ -1,0 +1,40 @@
+---
+- name: Single server iperf3 test
+  hosts: test_hosts
+  gather_facts: false
+  vars:
+    base_port: 5201
+    protocol: tcp
+    bandwidth: null
+  tasks:
+    - name: Build iperf3 client instance list
+      ansible.builtin.set_fact:
+        iperf3_client_instances: >-
+          {{ iperf3_client_instances | default([]) + [
+              {
+                'name': server_host,
+                'target': hostvars[server_host].test_ip.split('/') | first,
+                'port': base_port,
+                'protocol': protocol
+              } | combine(
+                (protocol == 'udp' and bandwidth is not none)
+                | ternary({'bandwidth': bandwidth}, {})
+              )
+            ]
+          }}
+      when: inventory_hostname != server_host
+
+    - name: Configure iperf3 server
+      ansible.builtin.include_role:
+        name: nsys.netperftesting.iperf3_server
+      vars:
+        iperf3_server_instances:
+          - "{{ base_port }}"
+      when: inventory_hostname == server_host
+
+    - name: Configure iperf3 clients
+      ansible.builtin.include_role:
+        name: nsys.netperftesting.iperf3_client
+      vars:
+        iperf3_client_base_port: "{{ base_port }}"
+      when: inventory_hostname != server_host


### PR DESCRIPTION
## Summary
- add playbook to run iperf3 clients against a designated server
- document usage of new single server playbook

## Testing
- `yamllint netperftesting/playbooks/netperf_single_server.yml`
- `ansible-lint netperftesting/playbooks/netperf_single_server.yml`


------
https://chatgpt.com/codex/tasks/task_b_68a4b9b9e70883248375ead609d94933