### PR TITLE
Add optional iperf base prefix for service and log isolation

### DIFF
--- a/netperftesting/molecule/default/verify.yml
+++ b/netperftesting/molecule/default/verify.yml
@@ -4,16 +4,16 @@
   gather_facts: false
   tasks:
     - name: Check iperf3 server service
-      ansible.builtin.command: systemctl is-active iperf3@5201
+      ansible.builtin.command: "systemctl is-active iperf3{{ iperf_base_prefix | default('') }}@5201"
       changed_when: false
       when: "'servers' in group_names"
 
     - name: Check iperf3 client to server1 service
-      ansible.builtin.command: systemctl is-active iperf3-client@to-server1
+      ansible.builtin.command: "systemctl is-active iperf3{{ iperf_base_prefix | default('') }}-client@to-server1"
       changed_when: false
       when: inventory_hostname == 'client1'
 
     - name: Check iperf3 client to server2 service
-      ansible.builtin.command: systemctl is-active iperf3-client@to-server2
+      ansible.builtin.command: "systemctl is-active iperf3{{ iperf_base_prefix | default('') }}-client@to-server2"
       changed_when: false
       when: inventory_hostname == 'client2'

--- a/netperftesting/playbooks/netperf_cleanup.yml
+++ b/netperftesting/playbooks/netperf_cleanup.yml
@@ -1,0 +1,8 @@
+---
+- name: Clean iperf3 settings
+  hosts: test_hosts
+  gather_facts: false
+  vars:
+    iperf3_cleanup_remove_package: false
+  roles:
+  - role: iperf3_cleanup

--- a/netperftesting/playbooks/netperf_fullmesh.yml
+++ b/netperftesting/playbooks/netperf_fullmesh.yml
@@ -5,6 +5,7 @@
   collections:
     - nsys.netperftesting
   vars:
+    iperf_base_prefix: "fullmesh"
     base_port: 5200
   tasks:
     - name: Initialize instance lists

--- a/netperftesting/playbooks/netperf_single_client.yml
+++ b/netperftesting/playbooks/netperf_single_client.yml
@@ -3,6 +3,7 @@
   hosts: test_hosts
   gather_facts: false
   vars:
+    iperf_base_prefix: "singeclient"
     base_port: 5201
     protocol: tcp
     bandwidth: null

--- a/netperftesting/playbooks/netperf_single_server.yml
+++ b/netperftesting/playbooks/netperf_single_server.yml
@@ -3,6 +3,7 @@
   hosts: test_hosts
   gather_facts: false
   vars:
+    iperf_base_prefix: "singleserver"
     base_port: 5201
     protocol: tcp
     bandwidth: null

--- a/netperftesting/playbooks/netperf_stress.yml
+++ b/netperftesting/playbooks/netperf_stress.yml
@@ -3,6 +3,7 @@
   hosts: test_hosts
   gather_facts: false
   vars:
+    iperf_base_prefix: "stresstest"
     base_port: 5200
     connections_per_pair: 1
     test_duration: 600

--- a/netperftesting/roles/iperf3_cleanup/README.md
+++ b/netperftesting/roles/iperf3_cleanup/README.md
@@ -9,7 +9,8 @@ and cleanup.
 
 ## Role Variables
 - `iperf3_cleanup_remove_package` (bool, default: `true`): whether to remove the iperf3 package.
+- `iperf_base_prefix` (string, default: ``): prefix appended to `iperf3` in service and log names to avoid collisions.
 - `iperf3_client_package` (string, default: `iperf3`): package name to remove.
-- `iperf3_client_conf_dir` (string, default: `/etc/iperf3-client`): client configuration directory.
-- `iperf3_client_log_dir` (string, default: `/var/log/iperf3-client`): client log directory.
-- `iperf3_server_log_dir` (string, default: `/var/log/iperf3`): server log directory.
+- `iperf3_client_conf_dir` (string, default: `/etc/iperf3<prefix>-client`): client configuration directory.
+- `iperf3_client_log_dir` (string, default: `/var/log/iperf3<prefix>-client`): client log directory.
+- `iperf3_server_log_dir` (string, default: `/var/log/iperf3<prefix>`): server log directory.

--- a/netperftesting/roles/iperf3_cleanup/defaults/main.yml
+++ b/netperftesting/roles/iperf3_cleanup/defaults/main.yml
@@ -3,7 +3,8 @@ iperf3_cleanup_remove_package: true
 
 # Reuse service role variables so the same values can be supplied for
 # setup and teardown.
+iperf_base_prefix: ""
 iperf3_client_package: iperf3  # noqa var-naming
-iperf3_client_conf_dir: /etc/iperf3-client  # noqa var-naming
-iperf3_client_log_dir: /var/log/iperf3-client  # noqa var-naming
-iperf3_server_log_dir: /var/log/iperf3  # noqa var-naming
+iperf3_client_conf_dir: "/etc/iperf3{{ iperf_base_prefix }}-client"  # noqa var-naming
+iperf3_client_log_dir: "/var/log/iperf3{{ iperf_base_prefix }}-client"  # noqa var-naming
+iperf3_server_log_dir: "/var/log/iperf3{{ iperf_base_prefix }}"  # noqa var-naming

--- a/netperftesting/roles/iperf3_cleanup/tasks/main.yml
+++ b/netperftesting/roles/iperf3_cleanup/tasks/main.yml
@@ -5,9 +5,11 @@
 
 - name: Collect iperf3 service units
   ansible.builtin.set_fact:
-    iperf3_cleanup_services: >-
-      {{ ansible_facts.services | dict2items | map(attribute='key') |
-         select('match', '^iperf3{{ iperf_base_prefix | regex_escape }}(-client)?@.*\\.service$') | list }}
+    iperf3_cleanup_services: "{{ ansible_facts.services | dict2items | map(attribute='key') | select('match', 'iperf3*') | list }}"
+#   {{ iperf_base_prefix | regex_escape }}?@.*\\.service$') | list }}
+- name: debug
+  debug:
+    msg: "{{ iperf3_cleanup_services }}"
 
 - name: Stop and disable iperf3 services
   ansible.builtin.systemd:

--- a/netperftesting/roles/iperf3_cleanup/tasks/main.yml
+++ b/netperftesting/roles/iperf3_cleanup/tasks/main.yml
@@ -7,7 +7,7 @@
   ansible.builtin.set_fact:
     iperf3_cleanup_services: >-
       {{ ansible_facts.services | dict2items | map(attribute='key') |
-         select('match', '^iperf3(-client)?@.*\\.service$') | list }}
+         select('match', '^iperf3{{ iperf_base_prefix | regex_escape }}(-client)?@.*\\.service$') | list }}
 
 - name: Stop and disable iperf3 services
   ansible.builtin.systemd:
@@ -40,14 +40,14 @@
 
 - name: Remove iperf3 client systemd template
   ansible.builtin.file:
-    path: /etc/systemd/system/iperf3-client@.service
+    path: "/etc/systemd/system/iperf3{{ iperf_base_prefix }}-client@.service"
     state: absent
   notify: Reload systemd
   become: true
 
 - name: Remove iperf3 server systemd template
   ansible.builtin.file:
-    path: /etc/systemd/system/iperf3@.service
+    path: "/etc/systemd/system/iperf3{{ iperf_base_prefix }}@.service"
     state: absent
   notify: Reload systemd
   become: true

--- a/netperftesting/roles/iperf3_client/README.md
+++ b/netperftesting/roles/iperf3_client/README.md
@@ -11,6 +11,9 @@ directory is owned by it.
 
 ## Variables
 
+- `iperf_base_prefix`: Optional string appended to the base `iperf3` name.
+  When set, services, configuration directories and log paths are prefixed
+  as `iperf3<prefix>` to avoid overwriting existing runs. Defaults to empty.
 - `iperf3_client_instances`: List of client service definitions. Each item
   should include:
   - `name`: Instance name (used for configuration file and systemd unit)
@@ -21,17 +24,17 @@ directory is owned by it.
   - `extra_args` (optional): Additional iperf3 arguments
 
 - `iperf3_client_log_dir`: Directory where JSON output from each client run
-  is stored. Log files are named `<client>-to-<instance>.json` where
+  is stored. Log files are named `<client>-to-<instance><prefix>.json` where
   `<client>` is the Ansible inventory hostname and `<instance>` is the service
-  instance name. Defaults to `/var/log/iperf3-client`.
+  instance name. Defaults to `/var/log/iperf3<prefix>-client`.
 
 - `iperf3_client_auto_start`: Whether client services should be started
   automatically after configuration. Defaults to `true`.
 - `iperf3_client_auto_enable`: Whether client services should be enabled to
   start at boot. Defaults to `true`.
 - `iperf3_client_log_dir`: Directory for iperf3 client log files. Defaults to
-  `/var/log/iperf3-client` and is created with permissions suitable for the
-  `nobody` user.
+  `/var/log/iperf3<prefix>-client` and is created with permissions suitable for
+  the `nobody` user.
 
 Example:
 

--- a/netperftesting/roles/iperf3_client/defaults/main.yml
+++ b/netperftesting/roles/iperf3_client/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
+iperf_base_prefix: ""
 iperf3_client_package: iperf3
-iperf3_client_conf_dir: /etc/iperf3-client
-iperf3_client_log_dir: /var/log/iperf3-client
+iperf3_client_conf_dir: "/etc/iperf3{{ iperf_base_prefix }}-client"
+iperf3_client_log_dir: "/var/log/iperf3{{ iperf_base_prefix }}-client"
 iperf3_client_base_port: 5201
 iperf3_client_instances: []
 iperf3_client_auto_start: true

--- a/netperftesting/roles/iperf3_client/tasks/main.yml
+++ b/netperftesting/roles/iperf3_client/tasks/main.yml
@@ -35,7 +35,7 @@
 - name: Deploy iperf3 client systemd template
   ansible.builtin.template:
     src: iperf3-client@.service.j2
-    dest: /etc/systemd/system/iperf3-client@.service
+    dest: "/etc/systemd/system/iperf3{{ iperf_base_prefix }}-client@.service"
     owner: root
     group: root
     mode: '0644'
@@ -72,12 +72,12 @@
 
 - name: Enable and start iperf3 client services
   ansible.builtin.systemd:
-    name: "iperf3-client@{{ item.name }}"
+    name: "iperf3{{ iperf_base_prefix }}-client@{{ item.name }}"
     enabled: "{{ iperf3_client_auto_enable }}"
     state: "{{ 'started' if iperf3_client_auto_start else 'stopped' }}"
   loop: "{{ iperf3_client_instances }}"
   loop_control:
-    label: "iperf3-client@{{ item.name }}"
+    label: "iperf3{{ iperf_base_prefix }}-client@{{ item.name }}"
   when: iperf3_client_instances | length > 0
   changed_when: false
   become: true

--- a/netperftesting/roles/iperf3_client/templates/iperf3-client@.service.j2
+++ b/netperftesting/roles/iperf3_client/templates/iperf3-client@.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=iperf3 client instance %i
+Description=iperf3{{ iperf_base_prefix }} client instance %i
 After=network-online.target
 Wants=network-online.target
 
@@ -8,10 +8,10 @@ Type=simple
 User=iperf3
 Group=iperf3
 EnvironmentFile=-{{ iperf3_client_conf_dir }}/%i.conf
-ExecStart=/bin/sh -c "/usr/bin/iperf3 -c $TARGET_IP -p $TARGET_PORT $PROTOCOL $EXTRA_ARGS -J | tee {{ iperf3_client_log_dir }}/{{ inventory_hostname }}-to-%i.json"
+ExecStart=/bin/sh -c "/usr/bin/iperf3 -c $TARGET_IP -p $TARGET_PORT $PROTOCOL $EXTRA_ARGS -J | tee {{ iperf3_client_log_dir }}/{{ inventory_hostname }}-to-%i{{ iperf_base_prefix }}.json"
 Restart=on-failure
 StandardError=journal
-SyslogIdentifier=iperf3-client-%i
+SyslogIdentifier=iperf3{{ iperf_base_prefix }}-client-%i
 
 [Install]
 WantedBy=multi-user.target

--- a/netperftesting/roles/iperf3_server/README.md
+++ b/netperftesting/roles/iperf3_server/README.md
@@ -7,5 +7,8 @@ privileges.
 
 ## Variables
 
+- `iperf_base_prefix`: Optional string appended to the base `iperf3` name.
+  When set, systemd services and log identifiers are prefixed as
+  `iperf3<prefix>` to avoid collisions. Defaults to empty.
 - `iperf3_server_instances`: List of ports to run server instances on.
   Defaults to `[]`.

--- a/netperftesting/roles/iperf3_server/defaults/main.yml
+++ b/netperftesting/roles/iperf3_server/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
+iperf_base_prefix: ""
 iperf3_server_package: iperf3
 iperf3_server_instances: []

--- a/netperftesting/roles/iperf3_server/tasks/main.yml
+++ b/netperftesting/roles/iperf3_server/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: Deploy iperf3 systemd template
   ansible.builtin.template:
     src: iperf3@.service.j2
-    dest: /etc/systemd/system/iperf3@.service
+    dest: "/etc/systemd/system/iperf3{{ iperf_base_prefix }}@.service"
     owner: root
     group: root
     mode: '0644'
@@ -26,7 +26,7 @@
 
 - name: Enable iperf3 server instances
   ansible.builtin.systemd:
-    name: "iperf3@{{ item }}"
+    name: "iperf3{{ iperf_base_prefix }}@{{ item }}"
     enabled: true
     state: started
   loop: "{{ iperf3_server_instances }}"

--- a/netperftesting/roles/iperf3_server/templates/iperf3@.service.j2
+++ b/netperftesting/roles/iperf3_server/templates/iperf3@.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=iperf3 server on port %i
+Description=iperf3{{ iperf_base_prefix }} server on port %i
 After=network-online.target
 Wants=network-online.target
 
@@ -11,7 +11,7 @@ ExecStart=/usr/bin/iperf3 -s -p %i
 Restart=on-failure
 StandardOutput=journal
 StandardError=journal
-SyslogIdentifier=iperf3-server-%i
+SyslogIdentifier=iperf3{{ iperf_base_prefix }}-server-%i
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- allow overriding a shared `iperf_base_prefix` to suffix service, directory, and log names
- update iperf3 client/server roles and cleanup role to honor the prefix
- document new variable and adjust Molecule verification

## Testing
- `pip install -r dev-requirements.txt`
- `molecule test` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68a58fde5bf08324baed597db4007030